### PR TITLE
run tests as Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 sudo: required
 
 language: python
-python: 2.7
 
 services:
   - docker
 
 env:
-  - TOXENV=py27
+  matrix:
+    - TOXENV=py27-ansible20
+    - TOXENV=py27-ansibledevel
+    - TOXENV=docs
 
 install:
   - pip install codecov tox
 
 script:
-  - make test
-  - make docs
+  - tox
 
 after_success:
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py27
+envlist = py27-ansible{20,devel},docs
 
 [testenv]
 deps =
     coverage
     pytest-mock
-    git+https://github.com/ansible/ansible.git@devel#egg=ansible
+    ansible20: ansible>=2.0,<2.1
+    ansibledevel: git+https://github.com/ansible/ansible.git@devel#egg=ansible
 passenv =
     # DOCKER_*: required for docker-machine support
     DOCKER_*


### PR DESCRIPTION
To ensure goodplay works with different versions of ansible we run tests in a build matrix. Also we're running the docs creation as a separate build.