### PR TITLE
allow Travis CI build for TOXENV=py27-ansibledevel to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ env:
     - TOXENV=py27-ansibledevel
     - TOXENV=docs
 
+matrix:
+  allow_failures:
+    env: TOXENV=py27-ansibledevel
+  fast_finish: true
+
 cache:
   - $HOME/.pip-cache
 


### PR DESCRIPTION
As it is not unusual for ansible@devel to fail, this should not hinder us.